### PR TITLE
feat: add nsa_provider_port configuration for flexible SOAP provider deployment

### DIFF
--- a/src/supa/__init__.py
+++ b/src/supa/__init__.py
@@ -203,7 +203,8 @@ class Settings(BaseSettings):
     nsa_host: str = "localhost"
     nsa_port: str = "8080"
     nsa_name: str = "example.domain uPA"
-    nsa_provider_path: str = "/provider"
+    nsa_provider_port: str = "8443"
+    nsa_provider_path: str = "/soap/connection/provider"
     nsa_topology_path: str = "/topology"
     nsa_discovery_path: str = "/discovery"
     nsa_owner_timestamp: str = "19700101T000000Z"
@@ -221,6 +222,11 @@ class Settings(BaseSettings):
     def nsa_exposed_url(self) -> str:
         """Return URL that NSA is exposed on constructed from nsa_scheme, nsa_host and nsa_port."""
         return f"{self.nsa_scheme}://{self.nsa_host}:{self.nsa_port}"
+
+    @property
+    def nsa_provider_exposed_url(self) -> str:
+        """Return Provider URL that NSA is exposed on constructed from nsa_scheme, nsa_host and nsa_provider_port."""
+        return f"{self.nsa_scheme}://{self.nsa_host}:{self.nsa_provider_port}"
 
     @property
     def nsa_id(self) -> str:

--- a/src/supa/documents/discovery.py
+++ b/src/supa/documents/discovery.py
@@ -134,6 +134,6 @@ class DiscoveryEndpoint(object):
         topology_type.text = "application/vnd.ogf.nsi.topology.v2+xml"
         topology_href.text = f"{settings.nsa_exposed_url}{settings.nsa_topology_path}"
         provider_type.text = "application/vnd.ogf.nsi.cs.v2.provider+soap"
-        provider_href.text = f"{settings.nsa_exposed_url}{settings.nsa_provider_path}"
+        provider_href.text = f"{settings.nsa_provider_exposed_url}{settings.nsa_provider_path}"
 
         return tostring(nsa, encoding="iso-8859-1", pretty_print=True)  # .decode('iso-8859-1')

--- a/src/supa/main.py
+++ b/src/supa/main.py
@@ -232,6 +232,11 @@ def cli() -> None:
     help="URL scheme of the exposed service.",
 )
 @click.option(
+    "--nsa_provider_port",
+    default=settings.nsa_provider_port,
+    help="Port of the NSI provider endpoint.",
+)
+@click.option(
     "--nsa-provider-path",
     default=settings.nsa_provider_path,
     help="Path of the NSI provider endpoint.",
@@ -313,6 +318,7 @@ def serve(
     nsa_port: str,
     nsa_name: str,
     nsa_scheme: str,
+    nsa_provider_port: str,
     nsa_provider_path: str,
     nsa_topology_path: str,
     nsa_discovery_path: str,
@@ -345,6 +351,7 @@ def serve(
     settings.nsa_port = nsa_port
     settings.nsa_name = nsa_name
     settings.nsa_scheme = nsa_scheme
+    settings.nsa_provider_port = nsa_provider_port
     settings.nsa_provider_path = nsa_provider_path
     settings.nsa_topology_path = nsa_topology_path
     settings.nsa_discovery_path = nsa_discovery_path

--- a/supa.env
+++ b/supa.env
@@ -56,11 +56,11 @@
 #grpc_server_max_workers=8
 
 # The host and port SuPA is listening on.
-grpc_server_insecure_host=localhost
+grpc_server_insecure_host=0.0.0.0
 grpc_server_insecure_port=50051
 
 # The host and port the Requester Agent/PolyNSI is listening on.
-grpc_client_insecure_host=localhost
+grpc_client_insecure_host=0.0.0.0
 grpc_client_insecure_port=9090
 
 # In addition to serving gRPC requests, SuPA does a fair amount of background
@@ -95,13 +95,15 @@ log_level=INFO
 # NSA Discovery and Topology document configuration
 #
 # Host and port the document server is deployed on
-document_server_host=localhost
+document_server_host=0.0.0.0
 document_server_port=4321
 # NSA (external) URL (scheme, host, port, path) that is exposed in the discovery document
 nsa_scheme=http
 nsa_host=localhost
 nsa_port=8080
-nsa_provider_path=/provider
+# PolyNSI NSI Protocol port and provider path.
+nsa_provider_port=8443
+nsa_provider_path=/soap/connection/provider
 nsa_topology_path=/topology
 nsa_discovery_path=/discovery
 # Discovery docuement meta data


### PR DESCRIPTION
# Add nsa_provider_port configuration for flexible SOAP provider deployment

## 🎯 Overview

This PR introduces the `nsa_provider_port` configuration option to enable flexible discovery document generation for SuPA deployments with PolyNSI SOAP proxy. The original implementation was designed for reverse proxy setups where both services are advertised through the same port in discovery documents. This enhancement adds support for advertising separate service endpoints while maintaining full backward compatibility.

## 🔍 Background

SuPA typically deploys with **PolyNSI** as a SOAP-to-gRPC proxy that enables NSI SOAP protocol communication. In such deployments:

- **SuPA** runs its document server and serves topology documents
- **PolyNSI** runs separately as a SOAP proxy, translating NSI SOAP requests to gRPC for SuPA
- **External services** (RA/DDS) need to discover both endpoints via SuPA's discovery document

PolyNSI typically runs with its own default configuration:
- **Default SOAP port**: `8443`
- **Default SOAP provider path**: `/soap/connection/provider`

The current unified port configuration generates discovery documents where both topology and SOAP provider interfaces use the same host:port combination, which works well with reverse proxy setups but doesn't match deployments where SuPA and PolyNSI run on different ports.

## 💡 Solution

Add `nsa_provider_port` configuration to allow separate port specification for SOAP provider service URLs in discovery documents, enabling discovery documents to correctly advertise PolyNSI's actual endpoint alongside SuPA's topology service endpoint.

## 📋 Key Changes

### New Configuration Option
- ✅ **`nsa_provider_port`**: Configurable port for SOAP provider URLs in discovery documents (default: `8443` - PolyNSI default)
- ✅ **Updated `nsa_provider_path`**: Updated default to `/soap/connection/provider` (PolyNSI default)

### CLI Support
- ✅ Add `--nsa_provider_port` command-line option
- ✅ Integrate with existing configuration system

### Discovery Document Update
- ✅ Generate SOAP provider interface URLs using separate port configuration
- ✅ Maintain topology interface URLs unchanged

## 🔧 Configuration Usage

### PolyNSI-Aware Discovery Document (New)
```bash
# supa.env - advertise PolyNSI's actual endpoint
nsa_host=example.org
nsa_port=8080                    # SuPA document server port
nsa_provider_port=8443           # PolyNSI SOAP port
nsa_provider_path=/soap/connection/provider  # PolyNSI default path
```

**Discovery document output:**
- Topology: `http://example.org:8080/topology` (points to SuPA)
- SOAP Provider: `http://example.org:8443/soap/connection/provider` (points to PolyNSI)

### Unified Discovery Document (Existing)
```bash
# supa.env - reverse proxy setup
nsa_host=example.org
nsa_port=8080                            # Same port advertised for both services
nsa_provider_path=/provider
```

**Discovery document output:**
- Topology: `http://example.org:8080/topology`
- SOAP Provider: `http://example.org:8080/provider`
