### PR TITLE
Bump starlette to 1.3.1 to fix CVE-2026-54283

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2101,15 +2101,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/37/cc24e33974e1439cf5ca62b0735b63026eabb768f472d8775f52d5851ed9/starlette-1.3.0.tar.gz", hash = "sha256:bb58cbb7a699da4ee4be9ed4cdfe4bc5b0390aa6dac1d1ac714ebebe8dc3c8df", size = 2702493, upload-time = "2026-06-11T06:27:41.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/42/56d31c5ee52dab0ad893d67d4f9c00f5ba2b4c5d87f392eca2c3fdce01cf/starlette-1.3.0-py3-none-any.whl", hash = "sha256:ff4ca1bc23de6a45cdfbbeb9b3caaea524c9221cdd8a6684ad7a4f651a83890b", size = 73492, upload-time = "2026-06-11T06:27:40.444Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps the transitive `starlette` dependency `1.2.1 → 1.3.1` (lock-only) to clear Dependabot alert #25.

## Why

`starlette < 1.3.1` silently ignores the `max_fields` / `max_part_size` limits of `request.form()` for `application/x-www-form-urlencoded` bodies, enabling an unauthenticated DoS — GHSA-82w8-qh3p-5jfq / CVE-2026-54283, high (CVSS 7.5).

Pulled in transitively via `mcp[cli]`; `mcp` and `sse-starlette` set no upper bound on starlette, so this resolves cleanly with no other changes.

## Exposure

Low in practice: SuPA never calls `request.form()`, and its only HTTP surface is the MCP `streamable_http_app()` (JSON-RPC over POST, no url-encoded form parsing). This is alert-clearing hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)